### PR TITLE
Add button to resume/suspend audioContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,22 @@
 	<head>
 		<title>Volume Meter Sample</title>
 		<style>
+			button {
+				padding: 10px;
+				margin-top: 10px;
+			}
+			body {
+				display: flex;
+				flex-direction: column;
+				align-items: flex-start;
+			}
 		</style>
-		
 	</head>
 	<body>
-
-    <video controls></video>
-    <canvas id="meter" width="500" height="50" style="z-index: 99999;"></canvas>
-
-
+		<video controls></video>
+		<canvas id="meter" width="500" height="50" style="z-index: 99999;"></canvas>
+		<button>Resume/suspend volume meter</button>
 		<script src="volume-meter.js"></script>
 		<script src="main.js"></script>
-
 	</body>
 </html>

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ var canvasContext = null;
 var WIDTH=500;
 var HEIGHT=50;
 var rafID = null;
+const buttonEl = document.querySelector('button');
 
 window.onload = function() {
 
@@ -46,7 +47,7 @@ window.onload = function() {
 
 // НЕУДАЧА
 function didntGetStream() {
-    alert('Stream generation failed.');
+    alert('Stream generation failed. Do you have at least one camera connected?');
 }
 
 var mediaStreamSource = null;
@@ -81,3 +82,12 @@ function drawLoop( time ) {
     // set up the next visual callback
     rafID = window.requestAnimationFrame( drawLoop );
 }
+
+buttonEl.addEventListener('click', function() {
+    if (audioContext.state === 'suspended') {
+        audioContext.resume();
+    }
+    if (audioContext.state === 'running') {
+        audioContext.suspend();
+    }
+})


### PR DESCRIPTION
Chrome displays this warning in the console:
`The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page.`

To resolve this issue (#1) I added a button which toggles the state of AudioContext. Chrome users are able to click it to show the meter initially. I also added a bit of styling.